### PR TITLE
Fix GitHub stats badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@
 
 ## 📈 GitHub Stats
 
-![GitHub Stats](https://github-readme-streak-stats.herokuapp.com/?user=nm24781-cyber&theme=dark&date_format=M%20j%5B%2C%20Y%5D)
+![GitHub Stats](https://streak-stats.demolab.com/?user=nm24781-cyber&theme=dark&date_format=M%20j%5B%2C%20Y%5D)
 
 ---


### PR DESCRIPTION
### Motivation
- The GitHub streak stats image source `https://github-readme-streak-stats.herokuapp.com/?user=nm24781-cyber&theme=dark&date_format=M%20j%5B%2C%20Y%5D` was broken and needed to be updated to a working endpoint.

### Description
- Updated the badge URL in `README.md` to `https://streak-stats.demolab.com/?user=nm24781-cyber&theme=dark&date_format=M%20j%5B%2C%20Y%5D` so the GitHub stats render correctly.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696886a05f08832bb22857bc623788b0)