### PR TITLE
Polish README layout and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,34 @@
+<div align="center">
+
 # Neeraj Mahajan
 
-### Senior Software Engineer @ Amazon | Tech Enthusiast | Innovator
+**Senior Software Engineer @ Amazon | Tech Enthusiast | Innovator**
 
-👋 Hi there! I'm Neeraj, a passionate Software Engineer with over 5 years of experience specializing in end-to-end software development and team leadership.
+<p>
+  <a href="https://linkedin.com/in/neeraj-mahajan-pro"><img alt="LinkedIn" src="https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white"></a>
+  <a href="https://github.com/nm24781-cyber"><img alt="GitHub" src="https://img.shields.io/badge/GitHub-171515?style=for-the-badge&logo=github&logoColor=white"></a>
+  <a href="mailto:nm24781@gmail.com"><img alt="Email" src="https://img.shields.io/badge/Email-EA4335?style=for-the-badge&logo=gmail&logoColor=white"></a>
+</p>
+
+<p>
+  <img alt="Profile Views" src="https://komarev.com/ghpvc/?username=nm24781-cyber&style=for-the-badge&color=blueviolet">
+</p>
 
 ---
 
-## Connect with me
-[![LinkedIn](https://img.shields.io/badge/-LinkedIn-blue?style=flat-square&logo=LinkedIn&logoColor=white)](https://linkedin.com/in/neeraj-mahajan-pro)
-[![GitHub](https://img.shields.io/badge/-GitHub-181717?style=flat-square&logo=github)](https://github.com/nm24781-cyber)
-[![Email](https://img.shields.io/badge/-Email-red?style=flat-square&logo=Gmail&logoColor=white)](mailto:nm24781@gmail.com)
+</div>
+
+## 👋 About Me
+
+I’m Neeraj, a software engineer with 5+ years of experience building scalable products, leading teams, and delivering end‑to‑end solutions. I love blending product thinking with clean engineering to create systems that are reliable, performant, and easy to evolve.
 
 ---
 
-## 🚀 Skills
+## 🚀 Skills & Tools
+
+<table>
+  <tr>
+    <td valign="top" width="50%">
 
 ### Core Software Development
 ![Java](https://img.shields.io/badge/Java-ED8B00?style=flat-square&logo=java&logoColor=white)
@@ -33,13 +48,16 @@
 ![Bootstrap](https://img.shields.io/badge/Bootstrap-7952B3?style=flat-square&logo=bootstrap&logoColor=white)
 ![Typescript](https://img.shields.io/badge/Typescript-3178C6?style=flat-square&logo=typescript&logoColor=white)
 
-### Version Control and Collaboration
+    </td>
+    <td valign="top" width="50%">
+
+### Version Control & Collaboration
 ![Git](https://img.shields.io/badge/Git-F05032?style=flat-square&logo=git&logoColor=white)
 ![GitHub](https://img.shields.io/badge/GitHub-100000?style=flat-square&logo=github&logoColor=white)
 ![Bitbucket](https://img.shields.io/badge/Bitbucket-0052CC?style=flat-square&logo=bitbucket&logoColor=white)
 ![Jira](https://img.shields.io/badge/Jira-0052CC?style=flat-square&logo=jira&logoColor=white)
 
-### Cloud and DevOps
+### Cloud & DevOps
 ![AWS](https://img.shields.io/badge/AWS-232F3E?style=flat-square&logo=amazon-aws&logoColor=white)
 ![Docker](https://img.shields.io/badge/Docker-2496ED?style=flat-square&logo=docker&logoColor=white)
 ![CI/CD](https://img.shields.io/badge/CI/CD-2088FF?style=flat-square&logo=gitlab&logoColor=white)
@@ -56,17 +74,29 @@
 ![Machine Learning](https://img.shields.io/badge/Machine_Learning-FF6F00?style=flat-square&logo=tensorflow&logoColor=white)
 ![Blockchain Development](https://img.shields.io/badge/Blockchain_Development-121D33?style=flat-square&logo=blockchain&logoColor=white)
 
-## 🏆 Achievements
+    </td>
+  </tr>
+</table>
 
-- 💡 **Top Merit Grant**: Received the prestigious Merit Grant at Syracuse University for exceptional academic performance, underscoring dedication and talent in software engineering.
-- 🏆 **Smart India Hackathon**: Secured 2nd place nationally in 2020, demonstrating innovative problem-solving skills and technical expertise in a competitive environment.
-- 📚 **Competitive Exam Success**: Holder of distinguished ranks in GATE, JEE Mains, and JEE Advance, reflecting exceptional analytical and technical proficiency.
-- 🎓 **Academic Distinction**: Ranked as a top performer in Computer Science during university studies, evidencing a consistent record of academic excellence and technical skillset.
+---
+
+## 🏆 Highlights & Achievements
+
+- 💡 **Top Merit Grant** — Syracuse University’s Merit Grant for exceptional academic performance.
+- 🏆 **Smart India Hackathon (2020)** — Secured **2nd place** nationally for innovative problem‑solving.
+- 📚 **Competitive Exams** — Distinguished ranks in **GATE**, **JEE Mains**, and **JEE Advance**.
+- 🎓 **Academic Distinction** — Consistently ranked top performer in Computer Science.
 
 ---
 
 ## 📈 GitHub Stats
 
-![GitHub Stats](https://streak-stats.demolab.com/?user=nm24781-cyber&theme=dark&date_format=M%20j%5B%2C%20Y%5D)
+![GitHub Stats](https://streak-stats.demolab.com/?user=nm24781-cyber&theme=tokyonight&date_format=M%20j%5B%2C%20Y%5D)
 
 ---
+
+<div align="center">
+
+### Let’s build something impactful.
+
+</div>


### PR DESCRIPTION
### Motivation
- Improve the README landing page aesthetics and readability by centering the hero, using prominent badges, and adding a short About section.
- Make skills and tooling easier to scan by reorganizing them into a compact two-column layout.
- Refresh the highlights and activity sections so achievements and GitHub stats stand out.

### Description
- Rewrote `README.md` header to use a centered hero with `for-the-badge` social badges and a profile views badge. 
- Added an `About Me` section and replaced the previous separate "Connect with me" block with inline badges. 
- Reorganized the skills into an HTML two-column table and normalized section headings and labels for clarity. 
- Refined achievements wording, switched the GitHub stats theme to `tokyonight`, and added a centered closing call-to-action.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968889ea8d8832ba88cd35ba59d785d)